### PR TITLE
Add deployment pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,12 +148,36 @@ jobs:
 
           echo "Container tag: ${{ steps.bump_version.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
 
-  deploy-dev:
+  deploy-development:
     name: Deploy to Development
     needs: push
     uses: ./.github/workflows/deploy.yml
     with:
       workspace_name: development
+      version_tag: ${{ needs.push.outputs.tag }}
+    secrets:
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy-preproduction:
+    name: Deploy to Preproduction
+    needs: deploy-development
+    uses: ./.github/workflows/deploy.yml
+    with:
+      workspace_name: preproduction
+      version_tag: ${{ needs.push.outputs.tag }}
+    secrets:
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy-production:
+    name: Deploy to Production
+    needs: deploy-preproduction
+    uses: ./.github/workflows/deploy.yml
+    with:
+      workspace_name: production
       version_tag: ${{ needs.push.outputs.tag }}
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,39 @@ defaults:
     shell: bash
 
 jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: "0"
+      - name: Image cache
+        uses: actions/cache@v3
+        with:
+          path: /tmp/images
+          key: ${{ runner.os }}-images-${{ github.run_id }}-${{ github.run_number }}
+      - name: Build Images
+        run: make build
+      - name: Trivy Image Vulnerability Scanner
+        uses: aquasecurity/trivy-action@0.10.0
+        with:
+          image-ref: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/integrations/lpa-uid-create-case-lambda:latest
+          severity: 'HIGH,CRITICAL'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+      - name: Upload Trivy scan results to GitHub Security tab
+        id: trivy_upload_sarif
+        uses: github/codeql-action/upload-sarif@v2
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'
+      - name: Save Images
+        run: |
+          mkdir -p /tmp/images
+          docker save -o /tmp/images/delegator.tar delegator:latest
+          docker save -o /tmp/images/lambda-create-case.tar 311462405659.dkr.ecr.eu-west-1.amazonaws.com/integrations/lpa-uid-create-case-lambda:latest
+
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -21,16 +54,30 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: "0"
-      - run: make up test-api
-
       - name: Run unit tests
         run: make test
 
-  push:
-    name: Bump tag
-    needs: [test]
+  integration-test:
+    name: Integration test
+    needs: [build]
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Image cache
+        uses: actions/cache@v3
+        with:
+          path: /tmp/images
+          key: ${{ runner.os }}-images-${{ github.run_id }}-${{ github.run_number }}
+      - name: Restore Images
+        run: |
+          docker load -i /tmp/images/delegator.tar
+          docker load -i /tmp/images/lambda-create-case.tar
+      - run: make up test-api
+
+  push:
+    name: Push images
+    needs: [test, integration-test]
+    runs-on: ubuntu-latest
     outputs:
       branch: ${{ steps.set-outputs.outputs.branch }}
       tag: ${{ steps.bump_version.outputs.tag }}
@@ -58,3 +105,57 @@ jobs:
           PRERELEASE_SUFFIX: ${{ env.BRANCH_NAME }}
           RELEASE_BRANCHES: main
           WITH_V: true
+
+      - uses: unfor19/install-aws-cli-action@v1
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-1
+          role-to-assume: arn:aws:iam::311462405659:role/integrations-ci
+          role-duration-seconds: 3600
+          role-session-name: GitHubActions
+
+      - name: ECR Login
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          registries: 311462405659
+
+      - name: Image cache
+        uses: actions/cache@v3
+        with:
+          path: /tmp/images
+          key: ${{ runner.os }}-images-${{ github.run_id }}-${{ github.run_number }}
+      - name: Restore Images
+        run: |
+          docker load -i /tmp/images/delegator.tar
+          docker load -i /tmp/images/lambda-create-case.tar
+
+      - name: Push Containers
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: integrations/lpa-uid-create-case-lambda
+        run: |
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:latest $ECR_REGISTRY/$ECR_REPOSITORY:${{ steps.bump_version.outputs.tag }}
+          if [ $BRANCH_NAME == "main" ]; then
+            # We want all of the tags pushed
+            docker push --all-tags $ECR_REGISTRY/$ECR_REPOSITORY
+          else
+            docker push $ECR_REGISTRY/$ECR_REPOSITORY:${{ steps.bump_version.outputs.tag }}
+          fi
+
+          echo "Container tag: ${{ steps.bump_version.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
+
+  deploy-dev:
+    name: Deploy to Development
+    needs: push
+    uses: ./.github/workflows/deploy.yml
+    with:
+      workspace_name: development
+      version_tag: ${{ needs.push.outputs.tag }}
+    secrets:
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      github_access_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,9 +46,6 @@ jobs:
           aws-region: eu-west-1
           role-duration-seconds: 3600
           role-session-name: OPGDataLpaUIDGithubAction
-      # - uses: webfactory/ssh-agent@v0.8.0
-      #   with:
-      #     ssh-private-key: ${{ secrets.ssh_deploy_key }}
 
       - name: Lint Terraform
         id: tf_lint
@@ -109,39 +106,11 @@ jobs:
               })
             }
 
-      # - name: Protect environment workspace
-      #   if: github.ref != 'refs/heads/main'
-      #   env:
-      #     TF_WORKSPACE: ${{ inputs.workspace_name }}
-      #     TF_VAR_app_version: ${{ inputs.version_tag }}
-      #   run: |
-      #     wget https://github.com/TomTucka/terraform-workspace-manager/releases/download/v0.3.1/terraform-workspace-manager_Linux_x86_64.tar.gz -O $HOME/terraform-workspace-manager.tar.gz
-      #     sudo tar -xvf $HOME/terraform-workspace-manager.tar.gz -C /usr/local/bin
-      #     sudo chmod +x /usr/local/bin/terraform-workspace-manager
-      #     terraform-workspace-manager -register-workspace=$TF_WORKSPACE -time-to-protect=24 -aws-account-id=653761790766 -aws-iam-role=modernising-lpa-ci
-      #   working-directory: ./terraform/aws
-
-      # - name: Terraform Apply
-      #   env:
-      #     TF_WORKSPACE: ${{ inputs.workspace_name }}
-      #     TF_VAR_app_version: ${{ inputs.version_tag }}
-      #   run: |
-      #     terraform apply -var public_access_enabled=${{ inputs.public_access_enabled }} -lock-timeout=300s -input=false -auto-approve -parallelism=30
-      #   working-directory: ./terraform/aws
-
-      # - name: upload environment config file
-      #   uses: actions/upload-artifact@v3
-      #   with:
-      #     name: environment_config_file
-      #     path: ./terraform/aws/environment_config.json
-
-      # - name: Terraform Outputs
-      #   id: terraform_outputs
-      #   env:
-      #     TF_WORKSPACE: ${{ inputs.workspace_name }}
-      #     TF_VAR_app_version: ${{ inputs.version_tag }}
-      #   run: |
-      #     echo "workspace_name=$(terraform output -raw workspace_name)" >> $GITHUB_OUTPUT
-      #     echo "container_version=$(terraform output -raw container_version)" >> $GITHUB_OUTPUT
-      #     echo "url=$(terraform output -raw app_fqdn)" >> $GITHUB_OUTPUT
-      #   working-directory: ./terraform/aws
+      - name: Terraform Apply
+        if: github.ref == 'refs/heads/main'
+        env:
+          TF_WORKSPACE: ${{ inputs.workspace_name }}
+          TF_VAR_app_version: ${{ inputs.version_tag }}
+        run: |
+          terraform apply -lock-timeout=300s -input=false -auto-approve -parallelism=30
+        working-directory: ./terraform/aws

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,147 @@
+name: "Deploy to Environment"
+
+on:
+  workflow_call:
+    inputs:
+      workspace_name:
+        description: "The terraform workspace to target for environment actions"
+        required: true
+        type: string
+      version_tag:
+        description: "The docker image tag to deploy in the environment"
+        required: true
+        type: string
+    secrets:
+      aws_access_key_id:
+        description: "AWS Access Key ID"
+        required: true
+      aws_secret_access_key:
+        description: "AWS Secret Access Key"
+        required: true
+      github_access_token:
+        description: "Github Token"
+        required: true
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  terraform_environment_workflow:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: "0"
+      - uses: unfor19/install-aws-cli-action@v1
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.4.6
+          terraform_wrapper: false
+      - name: Configure AWS Credentials For Terraform
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.aws_access_key_id }}
+          aws-secret-access-key: ${{ secrets.aws_secret_access_key }}
+          aws-region: eu-west-1
+          role-duration-seconds: 3600
+          role-session-name: OPGDataLpaUIDGithubAction
+      # - uses: webfactory/ssh-agent@v0.8.0
+      #   with:
+      #     ssh-private-key: ${{ secrets.ssh_deploy_key }}
+
+      - name: Lint Terraform
+        id: tf_lint
+        run: terraform fmt -check -recursive
+        working-directory: ./terraform/aws
+        continue-on-error: true
+
+      - name: Terraform Init
+        run: terraform init -input=false
+        working-directory: ./terraform/aws
+
+      - name: Terraform Plan
+        id: terraform_plan
+        env:
+          TF_WORKSPACE: ${{ inputs.workspace_name }}
+          TF_VAR_app_version: ${{ inputs.version_tag }}
+        run: |
+          terraform workspace show
+          echo "plan_summary=$(terraform plan -no-color -lock-timeout=300s -input=false -parallelism=30 | grep -ioE 'Plan: [[:digit:]]+ to add, [[:digit:]]+ to change, [[:digit:]]+ to destroy|No changes. Your infrastructure matches the configuration.')" >> $GITHUB_OUTPUT
+          terraform plan -lock-timeout=300s -input=false -parallelism=30
+
+        working-directory: ./terraform/aws
+
+      - uses: actions/github-script@v6
+        name: Add plan summary to PR comment
+        if: github.ref != 'refs/heads/main'
+        with:
+          github-token: ${{ secrets.github_access_token }}
+          script: |
+            // 1. Retrieve existing bot comments for the PR
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            })
+            const botComment = comments.find(comment => {
+              return comment.user.type === 'Bot' && comment.body.includes('PR Environment Terraform Plan Summary')
+            })
+
+            const output = `### PR Environment Terraform Plan Summary
+            \n
+            ${{ steps.terraform_plan.outputs.plan_summary }}`;
+
+            // 3. If we have a comment, update it, otherwise create a new one
+            if (botComment) {
+              github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: output
+              })
+            } else {
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: output
+              })
+            }
+
+      # - name: Protect environment workspace
+      #   if: github.ref != 'refs/heads/main'
+      #   env:
+      #     TF_WORKSPACE: ${{ inputs.workspace_name }}
+      #     TF_VAR_app_version: ${{ inputs.version_tag }}
+      #   run: |
+      #     wget https://github.com/TomTucka/terraform-workspace-manager/releases/download/v0.3.1/terraform-workspace-manager_Linux_x86_64.tar.gz -O $HOME/terraform-workspace-manager.tar.gz
+      #     sudo tar -xvf $HOME/terraform-workspace-manager.tar.gz -C /usr/local/bin
+      #     sudo chmod +x /usr/local/bin/terraform-workspace-manager
+      #     terraform-workspace-manager -register-workspace=$TF_WORKSPACE -time-to-protect=24 -aws-account-id=653761790766 -aws-iam-role=modernising-lpa-ci
+      #   working-directory: ./terraform/aws
+
+      # - name: Terraform Apply
+      #   env:
+      #     TF_WORKSPACE: ${{ inputs.workspace_name }}
+      #     TF_VAR_app_version: ${{ inputs.version_tag }}
+      #   run: |
+      #     terraform apply -var public_access_enabled=${{ inputs.public_access_enabled }} -lock-timeout=300s -input=false -auto-approve -parallelism=30
+      #   working-directory: ./terraform/aws
+
+      # - name: upload environment config file
+      #   uses: actions/upload-artifact@v3
+      #   with:
+      #     name: environment_config_file
+      #     path: ./terraform/aws/environment_config.json
+
+      # - name: Terraform Outputs
+      #   id: terraform_outputs
+      #   env:
+      #     TF_WORKSPACE: ${{ inputs.workspace_name }}
+      #     TF_VAR_app_version: ${{ inputs.version_tag }}
+      #   run: |
+      #     echo "workspace_name=$(terraform output -raw workspace_name)" >> $GITHUB_OUTPUT
+      #     echo "container_version=$(terraform output -raw container_version)" >> $GITHUB_OUTPUT
+      #     echo "url=$(terraform output -raw app_fqdn)" >> $GITHUB_OUTPUT
+      #   working-directory: ./terraform/aws

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 SHELL = '/bin/bash'
 
-up:
+build:
 	docker-compose build --parallel lambda-create-case delegator
+
+up:
 	docker-compose up -d localstack
 
 	cd terraform/local && terraform init

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.6"
 
 services:
   lambda-create-case:
-    image: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/lpa-uid/lambda/create-case:latest
+    image: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/integrations/lpa-uid-create-case-lambda:latest
     build:
       context: ./lambda/create-case
       dockerfile: ../Dockerfile
@@ -18,6 +18,7 @@ services:
     entrypoint: /aws-lambda/aws-lambda-rie /var/task/main
 
   delegator:
+    image: delegator
     depends_on: [lambda-create-case]
     build:
       context: ./delegator

--- a/terraform/aws/.envrc
+++ b/terraform/aws/.envrc
@@ -1,0 +1,6 @@
+# Terraform
+export TF_WORKSPACE=development
+export TF_VAR_default_role=operator
+export TF_VAR_management_role=operator
+
+export TF_CLI_ARGS_init="-backend-config=role_arn=arn:aws:iam::311462405659:role/operator"

--- a/terraform/aws/.terraform.lock.hcl
+++ b/terraform/aws/.terraform.lock.hcl
@@ -1,0 +1,61 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.66.1"
+  constraints = ">= 4.59.0"
+  hashes = [
+    "h1:AqQpXqwPd3bejoduTzc82UhMCzwirWE9I8hUOLsJDXY=",
+    "zh:001c707174b7d6bf89a96cf806f925bb852d1a285fb80b81222cbeb4743bcb79",
+    "zh:19bc6ac0a7fd1c564fd56c536f1743f71a5e7ca724e21ea51a6a79218939733d",
+    "zh:3dac5c27f40b511239e9fe6f97dc0b6c95f630ba328001820ddc764e766a5ca2",
+    "zh:49092c92e2565db4cd4c98ec6878386e6957525d3392b63f0d5df4c48a7c1913",
+    "zh:4f9e2e1d0c5365a4e6689096cc91ba88ca9c0dc7c633377ba674c1dd856b6a9f",
+    "zh:57e32bb454f2dc17d5631a9559e36188761d8ae95a452478f81f41bb568a3a42",
+    "zh:678b78ba629dd833f0705ac90630969f514a54013ab9713ce7ceda55fc5ea138",
+    "zh:8aab1d76348cf2a685f72382cb838a910b77353179e81ab5794b9c45c8fb36a3",
+    "zh:8b6791bf0948aa8b49258863992a8ad7e7332dcae1a889e86da0e5ab778dc3b6",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a36f2777452c2cebdaa8a27378416d512ead367acc078a671bb12276dd4bc9dd",
+    "zh:c492e6f685882fad6481f4793e696d9e1b01aaae419225c2db0a484b632d1cac",
+    "zh:d4418e0d1d18e321db364a91d7a768e274bb0fb46df9f3cb5b9debb2bb6917b9",
+    "zh:d5b4310ef2b2ec22ae14cf909deb1231b56bdd79dc2b51e5db4e46a05e0110c4",
+    "zh:dedfb01e26b34fb61a52b7e953b8bf5d7a69971187e91697b67221298bbed377",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.2.1"
+  hashes = [
+    "h1:tSj1mL6OQ8ILGqR2mDu7OYYYWf+hoir0pf9KAQ8IzO8=",
+    "zh:58ed64389620cc7b82f01332e27723856422820cfd302e304b5f6c3436fb9840",
+    "zh:62a5cc82c3b2ddef7ef3a6f2fedb7b9b3deff4ab7b414938b08e51d6e8be87cb",
+    "zh:63cff4de03af983175a7e37e52d4bd89d990be256b16b5c7f919aff5ad485aa5",
+    "zh:74cb22c6700e48486b7cabefa10b33b801dfcab56f1a6ac9b6624531f3d36ea3",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79e553aff77f1cfa9012a2218b8238dd672ea5e1b2924775ac9ac24d2a75c238",
+    "zh:a1e06ddda0b5ac48f7e7c7d59e1ab5a4073bbcf876c73c0299e4610ed53859dc",
+    "zh:c37a97090f1a82222925d45d84483b2aa702ef7ab66532af6cbcfb567818b970",
+    "zh:e4453fbebf90c53ca3323a92e7ca0f9961427d2f0ce0d2b65523cc04d5d999c2",
+    "zh:e80a746921946d8b6761e77305b752ad188da60688cfd2059322875d363be5f5",
+    "zh:fbdb892d9822ed0e4cb60f2fedbdbb556e4da0d88d3b942ae963ed6ff091e48f",
+    "zh:fca01a623d90d0cad0843102f9b8b9fe0d3ff8244593bd817f126582b52dd694",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/template" {
+  version = "2.2.0"
+  hashes = [
+    "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
+    "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
+    "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
+    "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
+    "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
+    "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
+    "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
+    "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
+    "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
+    "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
+    "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
+  ]
+}

--- a/terraform/aws/global.tf
+++ b/terraform/aws/global.tf
@@ -1,0 +1,9 @@
+module "global" {
+  source = "../modules/global"
+
+  environment_name = local.environment_name
+
+  providers = {
+    aws = aws.global
+  }
+}

--- a/terraform/aws/regions.tf
+++ b/terraform/aws/regions.tf
@@ -1,8 +1,7 @@
 module "eu-west-1" {
   source     = "../modules/region"
-  depends_on = [module.local_setup]
 
-  app_version      = "latest"
+  app_version      = var.app_version
   environment_name = local.environment_name
   environment      = local.environment
   is_local         = local.is_local
@@ -17,9 +16,8 @@ module "eu-west-1" {
 
 module "eu-west-2" {
   source     = "../modules/region"
-  depends_on = [module.local_setup]
 
-  app_version           = "latest"
+  app_version           = var.app_version
   dynamodb_primary_arn  = module.eu-west-1.dynamodb_arn
   dynamodb_primary_name = module.eu-west-1.dynamodb_name
   environment_name      = local.environment_name

--- a/terraform/aws/terraform.tfvars.json
+++ b/terraform/aws/terraform.tfvars.json
@@ -1,5 +1,17 @@
 {
     "environments": {
+        "production": {
+            "account_id": "649098267436",
+            "account_name": "production"
+        },
+        "preproduction": {
+            "account_id": "492687888235",
+            "account_name": "preproduction"
+        },
+        "development": {
+            "account_id": "288342028542",
+            "account_name": "development"
+        },
         "default": {
             "account_id": "288342028542",
             "account_name": "development"

--- a/terraform/aws/terrraform.tf
+++ b/terraform/aws/terrraform.tf
@@ -4,7 +4,7 @@ terraform {
     key            = "opg-data-lpa-uid/terraform.tfstate"
     encrypt        = true
     region         = "eu-west-1"
-    role_arn       = "arn:aws:iam::311462405659:role/sirius-ci"
+    role_arn       = "arn:aws:iam::311462405659:role/integrations-ci"
     dynamodb_table = "remote_lock"
   }
 
@@ -34,6 +34,20 @@ provider "aws" {
 provider "aws" {
   alias  = "eu-west-1"
   region = "eu-west-1"
+
+  assume_role {
+    role_arn     = "arn:aws:iam::${local.environment.account_id}:role/${var.default_role}"
+    session_name = "terraform-session"
+  }
+
+  default_tags {
+    tags = local.default_tags
+  }
+}
+
+provider "aws" {
+  alias  = "eu-west-2"
+  region = "eu-west-2"
 
   assume_role {
     role_arn     = "arn:aws:iam::${local.environment.account_id}:role/${var.default_role}"

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -5,7 +5,7 @@ locals {
   is_local         = false
   mandatory_moj_tags = {
     business-unit    = "OPG"
-    application      = "LPA UID Service"
+    application      = "opg-data-lpa-uid"
     account          = local.environment.account_name
     environment-name = local.environment_name
     is-production    = terraform.workspace == "production" ? true : false

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -27,10 +27,14 @@ variable "environments" {
   )
 }
 
+variable "app_version" {
+  default = "latest"
+}
+
 variable "default_role" {
-  default = "operator"
+  default = "integrations-ci"
 }
 
 variable "management_role" {
-  default = "lpa-uid-ci"
+  default = "integrations-ci"
 }

--- a/terraform/modules/region/lambda.tf
+++ b/terraform/modules/region/lambda.tf
@@ -1,6 +1,6 @@
 resource "aws_lambda_function" "create_case" {
   function_name = "lpa-uid-create-case-${local.environment_name}"
-  image_uri     = "311462405659.dkr.ecr.eu-west-1.amazonaws.com/lpa-uid/lambda/create-case:latest"
+  image_uri     = "311462405659.dkr.ecr.eu-west-1.amazonaws.com/integrations/lpa-uid-create-case-lambda:${var.app_version}"
   package_type  = "Image"
   role          = var.lambda_iam_role.arn
   timeout       = 5

--- a/terraform/modules/region/variables.tf
+++ b/terraform/modules/region/variables.tf
@@ -20,6 +20,10 @@ variable "is_primary" {
 
 variable "lambda_iam_role" {}
 
+variable "app_version" {
+  type = string
+}
+
 locals {
   environment_name = "${var.environment_name}-${data.aws_region.current.name}"
 }


### PR DESCRIPTION
- Build and cache images
- Separate unit and integration tests
- Push image to ECR
- Deploy to development

For deployment I've used a pattern from opg-modernising-lpa which uses reusable workflows. I've also fleshed out the AWS workspace folder to create the region resources.

Fixes VEGA-1739 #minor