### PR TITLE
Ensure deploy stages have inputs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,15 +32,15 @@ jobs:
         uses: aquasecurity/trivy-action@0.10.0
         with:
           image-ref: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/integrations/lpa-uid-create-case-lambda:latest
-          severity: 'HIGH,CRITICAL'
-          format: 'sarif'
-          output: 'trivy-results.sarif'
+          severity: "HIGH,CRITICAL"
+          format: "sarif"
+          output: "trivy-results.sarif"
       - name: Upload Trivy scan results to GitHub Security tab
         id: trivy_upload_sarif
         uses: github/codeql-action/upload-sarif@v2
         if: always()
         with:
-          sarif_file: 'trivy-results.sarif'
+          sarif_file: "trivy-results.sarif"
       - name: Save Images
         run: |
           mkdir -p /tmp/images
@@ -162,7 +162,7 @@ jobs:
 
   deploy-preproduction:
     name: Deploy to Preproduction
-    needs: deploy-development
+    needs: [push, deploy-development]
     uses: ./.github/workflows/deploy.yml
     with:
       workspace_name: preproduction
@@ -174,7 +174,7 @@ jobs:
 
   deploy-production:
     name: Deploy to Production
-    needs: deploy-preproduction
+    needs: [push, deploy-preproduction]
     uses: ./.github/workflows/deploy.yml
     with:
       workspace_name: production


### PR DESCRIPTION
In order to reference `needs.push.outputs.tag`, the job must depend on the push job.

For VEGA-1739 #patch