### PR TITLE
Stop outputting plan in GitHub comment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,7 +158,6 @@ jobs:
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
   deploy-preproduction:
     name: Deploy to Preproduction
@@ -170,7 +169,6 @@ jobs:
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
   deploy-production:
     name: Deploy to Production
@@ -182,4 +180,3 @@ jobs:
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      github_access_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,13 +18,6 @@ on:
       aws_secret_access_key:
         description: "AWS Secret Access Key"
         required: true
-      github_access_token:
-        description: "Github Token"
-        required: true
-
-permissions:
-  pull-requests: write
-  issues: write
 
 jobs:
   terraform_environment_workflow:
@@ -68,43 +61,6 @@ jobs:
           terraform plan -lock-timeout=300s -input=false -parallelism=30
 
         working-directory: ./terraform/aws
-
-      - uses: actions/github-script@v6
-        name: Add plan summary to PR comment
-        if: github.ref != 'refs/heads/main'
-        with:
-          github-token: ${{ secrets.github_access_token }}
-          script: |
-            // 1. Retrieve existing bot comments for the PR
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            })
-            const botComment = comments.find(comment => {
-              return comment.user.type === 'Bot' && comment.body.includes('PR Environment Terraform Plan Summary')
-            })
-
-            const output = `### PR Environment Terraform Plan Summary
-            \n
-            ${{ steps.terraform_plan.outputs.plan_summary }}`;
-
-            // 3. If we have a comment, update it, otherwise create a new one
-            if (botComment) {
-              github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: botComment.id,
-                body: output
-              })
-            } else {
-              github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: output
-              })
-            }
 
       - name: Terraform Apply
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
Because we deploy to three environments, it overwrites itself and isn't very helpful.

For VEGA-1739 #patch