### PR TITLE
Add Pact Provider verification

### DIFF
--- a/.github/workflows/pact-provider-verification.yml
+++ b/.github/workflows/pact-provider-verification.yml
@@ -1,0 +1,47 @@
+name: Pact Provider Verification
+
+on:
+  repository_dispatch:
+    types: [provider-verification]
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: Provider verification
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: make build up
+      - name: Verify specified Pact
+        if: ${{ github.event_name == 'repository_dispatch' }}
+        run: |
+          docker-compose run --rm pact-verifier \
+            --provider-version=$(git rev-parse HEAD) \
+            --provider-branch=main \
+            --publish \
+            --user=admin \
+            --password=${{ secrets.PACT_BROKER_PASSWORD }} \
+            --url=${{ github.event.client_payload.pact_url }}
+      - name: Verify pacts, including pending
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          docker-compose run --rm pact-verifier \
+            --provider-version=$(git rev-parse HEAD) \
+            --provider-branch=main \
+            --publish \
+            --user=admin \
+            --password=${{ secrets.PACT_BROKER_PASSWORD }} \
+            --consumer-version-selectors='{"mainBranch": true}' \
+            --enable-pending
+      - name: Verify pacts are still upheld
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          docker-compose run --rm pact-verifier \
+            --provider-version=$(git rev-parse HEAD) \
+            --provider-branch=${{ github.head_ref }} \
+            --consumer-version-selectors='{"mainBranch": true}'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,10 @@ services:
       - "4566:4566"
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
+    networks:
+      default:
+        aliases:
+          - "lpa-uid.execute-api.localhost.localstack.cloud"
     environment:
       LAMBDA_FORWARD_URL: http://delegator:8080
       DOCKER_HOST: unix:///var/run/docker.sock
@@ -41,3 +45,13 @@ services:
       timeout: 10s
       retries: 3
       start_period: 30s
+
+  pact-verifier:
+    image: pactfoundation/pact-ref-verifier
+    entrypoint:
+      - pact_verifier_cli
+      - --hostname=lpa-uid.execute-api.localhost.localstack.cloud
+      - --port=4566
+      - --base-path=/current/
+      - --broker-url=https://pact-broker.api.opg.service.justice.gov.uk/
+      - --provider-name=data-lpa-uid

--- a/terraform/modules/region/api_gateway.tf
+++ b/terraform/modules/region/api_gateway.tf
@@ -10,6 +10,9 @@ resource "aws_api_gateway_rest_api" "lpa_uid" {
   name        = "lpa-uid-${terraform.workspace}"
   description = "API Gateway for LPA UID - ${local.environment_name}"
   body        = data.template_file._.rendered
+  tags = var.is_local ? {
+    _custom_id_ = "lpa-uid"
+  } : {}
 
   endpoint_configuration {
     types = ["REGIONAL"]


### PR DESCRIPTION
Verify pacts:
 - When making a PR, to ensure the contract hasn't been broken
 - When pushing to main, to ensure the contract hasn't been broken and to notify pending Pacts
 - When we receive a repository dispatch event of the type "provider-verification", to verify a specific Pact

Fixes VEGA-1753 #patch