### PR TITLE
MLPAB-985 - define the resources that can be accessed 

### DIFF
--- a/terraform/modules/region/api_gateway.tf
+++ b/terraform/modules/region/api_gateway.tf
@@ -121,7 +121,7 @@ data "aws_iam_policy_document" "lpa_uid" {
     }
 
     actions   = ["execute-api:Invoke"]
-    resources = ["${aws_api_gateway_rest_api.lpa_uid.execution_arn}/${aws_api_gateway_stage.current.stage_name}/*"]
+    resources = ["${aws_api_gateway_rest_api.lpa_uid.execution_arn}/${aws_api_gateway_stage.current.stage_name}/*/*/*"]
   }
 }
 


### PR DESCRIPTION
include wildcards for all methods and stages

Resource format of permissions shown here 
https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-control-access-using-iam-policies-to-invoke-api.html#api-gateway-calling-api-permissions

but format of execute-api defined here
https://docs.aws.amazon.com/apigateway/latest/developerguide/arn-format-reference.html

implies stage, http-method and resource-path need to be wilcarded too, else you get a forbidden error when calling.
