### PR TITLE
MLPAB-1036 - Fix DNS

### DIFF
--- a/terraform/modules/region/api_gateway.tf
+++ b/terraform/modules/region/api_gateway.tf
@@ -96,9 +96,8 @@ resource "aws_api_gateway_domain_name" "lpa_uid" {
 
 resource "aws_api_gateway_base_path_mapping" "mapping" {
   api_id      = aws_api_gateway_rest_api.lpa_uid.id
-  stage_name  = aws_api_gateway_deployment.lpa_uid.stage_name
+  stage_name  = aws_api_gateway_stage.current.stage_name
   domain_name = aws_api_gateway_domain_name.lpa_uid.domain_name
-  base_path   = aws_api_gateway_deployment.lpa_uid.stage_name
 }
 
 resource "aws_api_gateway_method_settings" "lpa_uid_gateway_settings" {


### PR DESCRIPTION
## Actions
- add stage name to custom domain mapping

The stage name from the api gateway deployment resource wasn't returning a value, so "current" wasn't being included in the custom domain mapping.

Adding it to the endpoint of any call would also solve this issue

for example

```shell
aws-vault exec <profile> -- go run uid-tester -baseUrl="https://lpa-uid.api.opg.service.justice.gov.uk/current"
```

This setup would allow for consumers of the API to choose what version (stage) they want to use if the api introduces breaking changes, but as including the stage name appears to be the intended setup, it is now taken from from the stage resource instead.


## Learning

https://docs.aws.amazon.com/apigateway/latest/developerguide/rest-api-mappings.html