### PR TITLE
MLPAB-1140 - BadRequestException: Deleting stage current failed

### DIFF
--- a/terraform/modules/region/api_gateway.tf
+++ b/terraform/modules/region/api_gateway.tf
@@ -38,7 +38,7 @@ resource "aws_api_gateway_deployment" "lpa_uid" {
   triggers = {
     redeployment = sha1(jsonencode([
       aws_api_gateway_rest_api.lpa_uid.body,
-      var.environment.allowed_arns]))
+    var.environment.allowed_arns]))
   }
 
   lifecycle {
@@ -98,6 +98,11 @@ resource "aws_api_gateway_base_path_mapping" "mapping" {
   api_id      = aws_api_gateway_rest_api.lpa_uid.id
   stage_name  = aws_api_gateway_stage.current.stage_name
   domain_name = aws_api_gateway_domain_name.lpa_uid.domain_name
+
+  lifecycle {
+    create_before_destroy = true
+    replace_triggered_by  = [null_resource.open_api]
+  }
 }
 
 resource "aws_api_gateway_method_settings" "lpa_uid_gateway_settings" {


### PR DESCRIPTION
## Purpose

Path to live fails to delete a stage because it's being used by base path mapping

## Approach

- redeployments now create new base path mappings instead of updating in place
- base path mappings are created before they are destroyed

This deposes existing resources and destroys them afterwards

```shell
module.eu-west-1.aws_api_gateway_stage.current: Creating...
module.eu-west-1.aws_api_gateway_stage.current: Creation complete after 1s
module.eu-west-1.aws_api_gateway_base_path_mapping.mapping: Creating...
module.eu-west-1.aws_api_gateway_base_path_mapping.mapping: Creation complete after 0s 
module.eu-west-1.aws_api_gateway_base_path_mapping.mapping (deposed object ce384f3a): Destroying... 
module.eu-west-1.aws_api_gateway_base_path_mapping.mapping: Destruction complete after 1s
module.eu-west-1.aws_api_gateway_stage.current (deposed object 3453720c): Destroying... 
module.eu-west-1.aws_api_gateway_stage.current: Destruction complete after 0s
module.eu-west-2.aws_api_gateway_stage.current: Creating...
module.eu-west-2.aws_api_gateway_stage.current: Creation complete after 1s
module.eu-west-2.aws_api_gateway_base_path_mapping.mapping: Creating...
module.eu-west-2.aws_api_gateway_base_path_mapping.mapping: Creation complete after 0s
module.eu-west-2.aws_api_gateway_base_path_mapping.mapping (deposed object bc72293d): Destroying... 
module.eu-west-2.aws_api_gateway_base_path_mapping.mapping: Destruction complete after 0s
module.eu-west-2.aws_api_gateway_stage.current (deposed object e5f3d7b5): Destroying... 
module.eu-west-2.aws_api_gateway_stage.current: Destruction complete after 1s
```