### PR TITLE
MLPAB-1118: Prefer int for status codes (duh)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -116,7 +116,7 @@ paths:
         type: "mock"
         responses:
           default:
-            statusCode: "200"
+            statusCode: 200
             responseTemplates:
               application/json: "{\"status\":\"ok\"}"
 


### PR DESCRIPTION
Seems like I'm not the only one - https://stackoverflow.com/questions/59911777/aws-api-gateway-and-static-html-execution-failed-due-to-configuration-error-s