### PR TITLE
MLPAB-1146 - Fix deployments

### DIFF
--- a/terraform/modules/region/api_gateway.tf
+++ b/terraform/modules/region/api_gateway.tf
@@ -37,7 +37,7 @@ resource "aws_api_gateway_deployment" "lpa_uid" {
 
   triggers = {
     redeployment = sha1(jsonencode([
-      aws_api_gateway_rest_api.lpa_uid.body,
+      aws_api_gateway_rest_api.lpa_uid,
     var.environment.allowed_arns]))
   }
 

--- a/terraform/modules/region/api_gateway.tf
+++ b/terraform/modules/region/api_gateway.tf
@@ -46,10 +46,6 @@ locals {
 }
 
 resource "aws_api_gateway_stage" "current" {
-  depends_on = [
-    aws_cloudwatch_log_group.lpa_uid,
-    aws_api_gateway_rest_api_policy.lpa_uid
-  ]
   deployment_id        = aws_api_gateway_deployment.lpa_uid.id
   rest_api_id          = aws_api_gateway_rest_api.lpa_uid.id
   stage_name           = local.stage_name

--- a/terraform/modules/region/api_gateway.tf
+++ b/terraform/modules/region/api_gateway.tf
@@ -111,6 +111,8 @@ resource "aws_api_gateway_method_settings" "lpa_uid_gateway_settings" {
 }
 
 data "aws_iam_policy_document" "lpa_uid" {
+  policy_id = "lpa-uid-${terraform.workspace}-${data.aws_region.current.name}-resource-policy"
+
   statement {
     sid    = "${local.policy_region_prefix}AllowExecutionFromAllowedARNs"
     effect = "Allow"

--- a/terraform/modules/region/api_gateway.tf
+++ b/terraform/modules/region/api_gateway.tf
@@ -46,9 +46,7 @@ locals {
 }
 
 resource "aws_api_gateway_stage" "current" {
-  depends_on = [
-    aws_cloudwatch_log_group.lpa_uid,
-  ]
+  depends_on           = [aws_cloudwatch_log_group.lpa_uid]
   deployment_id        = aws_api_gateway_deployment.lpa_uid.id
   rest_api_id          = aws_api_gateway_rest_api.lpa_uid.id
   stage_name           = local.stage_name

--- a/terraform/modules/region/api_gateway.tf
+++ b/terraform/modules/region/api_gateway.tf
@@ -15,35 +15,30 @@ resource "aws_api_gateway_rest_api" "lpa_uid" {
   endpoint_configuration {
     types = ["REGIONAL"]
   }
-
-  lifecycle {
-    replace_triggered_by = [null_resource.open_api]
-  }
-}
-
-resource "null_resource" "open_api" {
-  triggers = {
-    open_api_sha = local.open_api_sha
-  }
 }
 
 locals {
   open_api_sha = substr(replace(base64sha256(local.template_file), "/[^0-9A-Za-z_]/", ""), 0, 5)
 }
 
-
 resource "aws_api_gateway_deployment" "lpa_uid" {
   rest_api_id = aws_api_gateway_rest_api.lpa_uid.id
 
   triggers = {
     redeployment = sha1(jsonencode([
-      aws_api_gateway_rest_api.lpa_uid,
-    var.environment.allowed_arns]))
+      aws_api_gateway_rest_api.lpa_uid.body,
+      var.environment.allowed_arns
+    ]))
   }
 
   lifecycle {
     create_before_destroy = true
   }
+
+  depends_on = [
+    aws_api_gateway_rest_api.lpa_uid,
+    aws_api_gateway_rest_api_policy.lpa_uid
+  ]
 }
 
 locals {
@@ -51,11 +46,15 @@ locals {
 }
 
 resource "aws_api_gateway_stage" "current" {
-  depends_on           = [aws_cloudwatch_log_group.lpa_uid]
+  depends_on = [
+    aws_cloudwatch_log_group.lpa_uid,
+    aws_api_gateway_rest_api_policy.lpa_uid
+  ]
   deployment_id        = aws_api_gateway_deployment.lpa_uid.id
   rest_api_id          = aws_api_gateway_rest_api.lpa_uid.id
   stage_name           = local.stage_name
   xray_tracing_enabled = true
+
 
   access_log_settings {
     destination_arn = aws_cloudwatch_log_group.lpa_uid.arn
@@ -101,7 +100,7 @@ resource "aws_api_gateway_base_path_mapping" "mapping" {
 
   lifecycle {
     create_before_destroy = true
-    replace_triggered_by  = [null_resource.open_api]
+    # replace_triggered_by  = [null_resource.open_api]
   }
 }
 
@@ -127,7 +126,7 @@ data "aws_iam_policy_document" "lpa_uid" {
     }
 
     actions   = ["execute-api:Invoke"]
-    resources = ["${aws_api_gateway_rest_api.lpa_uid.execution_arn}/${aws_api_gateway_stage.current.stage_name}/*/*"]
+    resources = ["*"]
   }
 }
 

--- a/terraform/modules/region/api_gateway.tf
+++ b/terraform/modules/region/api_gateway.tf
@@ -46,6 +46,9 @@ locals {
 }
 
 resource "aws_api_gateway_stage" "current" {
+  depends_on = [
+    aws_cloudwatch_log_group.lpa_uid,
+  ]
   deployment_id        = aws_api_gateway_deployment.lpa_uid.id
   rest_api_id          = aws_api_gateway_rest_api.lpa_uid.id
   stage_name           = local.stage_name

--- a/terraform/modules/region/api_gateway.tf
+++ b/terraform/modules/region/api_gateway.tf
@@ -100,7 +100,6 @@ resource "aws_api_gateway_base_path_mapping" "mapping" {
 
   lifecycle {
     create_before_destroy = true
-    # replace_triggered_by  = [null_resource.open_api]
   }
 }
 

--- a/terraform/modules/region/api_gateway.tf
+++ b/terraform/modules/region/api_gateway.tf
@@ -52,7 +52,6 @@ resource "aws_api_gateway_stage" "current" {
   stage_name           = local.stage_name
   xray_tracing_enabled = true
 
-
   access_log_settings {
     destination_arn = aws_cloudwatch_log_group.lpa_uid.arn
     format = join("", [

--- a/terraform/modules/region/terraform.tf
+++ b/terraform/modules/region/terraform.tf
@@ -9,5 +9,9 @@ terraform {
         aws.management
       ]
     }
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.1"
+    }
   }
 }


### PR DESCRIPTION
## Problem

Changes to permissions or the body of the API were taking 2 deployments to come into play.

It seems that creating a new API on those changes using `replace_triggered_by` was causing an issue.

Removing this, and updating the triggers for deployments, we now only require one. New API paths are available immediately and permission changes take about 10 seconds to propagate.

Also, this seems to remove the need to recreate methods and stages as implemented previously.

## Approach

- simplified resource in API policy (as it's attached and only applies to a single api) to decouple the policy from the rest API.
- removed `replace_triggered_by` and the associated null resource
- make sure API and policy are ready before deploying