### PR TITLE
VEGA-1939 - Notify Sirius when new records created

### DIFF
--- a/terraform/aws/regions.tf
+++ b/terraform/aws/regions.tf
@@ -9,6 +9,7 @@ module "eu-west-1" {
   is_local                  = false
   is_primary                = true
   lambda_iam_role           = module.global.lambda_iam_role
+  target_event_bus_arn      = "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas"
 
   providers = {
     aws            = aws.eu-west-1
@@ -28,6 +29,7 @@ module "eu-west-2" {
   is_local                  = false
   is_primary                = false
   lambda_iam_role           = module.global.lambda_iam_role
+  target_event_bus_arn      = "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas"
 
   providers = {
     aws            = aws.eu-west-2

--- a/terraform/aws/terrraform.tf
+++ b/terraform/aws/terrraform.tf
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.59.0"
+      version = ">= 5.8.0"
     }
   }
   required_version = ">= 1.4.0"

--- a/terraform/local/.terraform.lock.hcl
+++ b/terraform/local/.terraform.lock.hcl
@@ -19,12 +19,29 @@ provider "registry.terraform.io/hashicorp/aws" {
     "h1:gFsITWUrCJk+MFJ+Z84uecb6DfHm4sKHlALQ95kcVUU=",
     "h1:mvg6WWqqUvgUq6wYCWg/zqpND/5yIz3plIL1IOR50Rs=",
     "h1:nrpn2/zvcILWjsaKAQqpaxa3gxzpFQncbatuuURt/sk=",
+    "zh:032424d4686ce2ff7c5a4a738491635616afbf6e06b3e7e6a754baa031d1265d",
+    "zh:1e530b4020544ec94e1fe7b1e4296640eb12cf1bf4f79cd6429ff2c4e6fffaf3",
+    "zh:24d2eee57a4c78039959dd9bb6dff2b75ed0483d44929550c067c3488307dc62",
+    "zh:3ad6d736722059664e790a358eacf0e0e60973ec44e70142fb503275de2116c1",
+    "zh:3f34d81acf86c61ddd271e9c4b8215765037463c3fe3c7aea1dc32a509020cfb",
+    "zh:65a04aa615fc320059a0871702c83b6be10bce2064056096b46faffe768a698e",
+    "zh:7fb56c3ce1fe77983627e2931e7c7b73152180c4dfb03e793413d0137c85d6b2",
+    "zh:90c94cb9d7352468bcd5ba21a56099fe087a072b1936d86f47d54c2a012b708a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a109c5f01ed48852fe17847fa8a116dfdb81500794a9cf7e5ef92ea6dec20431",
+    "zh:a27c5396077a36ac2801d4c1c1132201a9225a65bba0e3b3aded9cc18f2c38ff",
+    "zh:a86ad796ccb0f2cb8f0ca069c774dbf74964edd3282529726816c72e22164b3c",
+    "zh:bda8afc64091a2a72e0cc38fde937b2163b1b072a5c41310d255901207571afd",
+    "zh:d22473894cd7e94b7a971793dd07309569f82913a10e4bd6c22e04f362f03bb9",
+    "zh:f4dbb6d13511290a5274f5b202e6d9997643f86e4c48e8c5e3c204121082851a",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/null" {
-  version = "3.2.1"
+  version     = "3.2.1"
+  constraints = "3.2.1"
   hashes = [
+    "h1:tSj1mL6OQ8ILGqR2mDu7OYYYWf+hoir0pf9KAQ8IzO8=",
     "h1:ydA0/SNRVB1o95btfshvYsmxA+jZFRZcvKzZSB+4S1M=",
     "zh:58ed64389620cc7b82f01332e27723856422820cfd302e304b5f6c3436fb9840",
     "zh:62a5cc82c3b2ddef7ef3a6f2fedb7b9b3deff4ab7b414938b08e51d6e8be87cb",

--- a/terraform/local/regions.tf
+++ b/terraform/local/regions.tf
@@ -9,6 +9,7 @@ module "eu-west-1" {
   is_local                  = true
   is_primary                = true
   lambda_iam_role           = module.global.lambda_iam_role
+  target_event_bus_arn      = ""
 
   providers = {
     aws            = aws.eu-west-1
@@ -27,10 +28,10 @@ module "eu-west-2" {
   is_local                  = local.is_local
   is_primary                = false
   lambda_iam_role           = module.global.lambda_iam_role
+  target_event_bus_arn      = ""
 
   providers = {
     aws            = aws.eu-west-2
     aws.management = aws.management
   }
 }
-

--- a/terraform/modules/region/dynamodb.tf
+++ b/terraform/modules/region/dynamodb.tf
@@ -23,7 +23,7 @@ resource "aws_dynamodb_table" "lpa_uid" {
 
   server_side_encryption {
     enabled     = true
-    kms_key_arn = aws_kms_key.dynamodb[0].arn
+    kms_key_arn = var.is_primary ? aws_kms_key.dynamodb[0].arn : aws_kms_replica_key.dynamodb[0].arn
   }
 
   global_secondary_index {

--- a/terraform/modules/region/lpa_applications.tf
+++ b/terraform/modules/region/lpa_applications.tf
@@ -107,8 +107,7 @@ resource "aws_cloudwatch_event_rule" "receive_insert" {
   event_bus_name = aws_cloudwatch_event_bus.lpa_applications[0].name
 
   event_pattern  = jsonencode({
-    source      = ["lpa-applications"],
-    detail-type = ["insert"]
+    account = [local.environment.account_id]
   })
 }
 

--- a/terraform/modules/region/lpa_applications.tf
+++ b/terraform/modules/region/lpa_applications.tf
@@ -1,0 +1,128 @@
+# Send notification to event bridge when LPA application is made
+resource "aws_cloudwatch_event_bus" "lpa_applications" {
+  count = var.is_primary ? 1 : 0
+  name  = "${var.environment_name}-lpa-applications"
+}
+
+resource "aws_cloudwatch_event_archive" "lpa_applications" {
+  count            = var.is_primary ? 1 : 0
+  name             = "${var.environment_name}-lpa-applications"
+  event_source_arn = aws_cloudwatch_event_bus.lpa_applications[0].arn
+}
+
+# Event pipe to send events from dynamodb stream to event bus
+resource "aws_pipes_pipe" "lpa_applications" {
+  count         = var.is_primary ? 1 : 0
+  name          = "${var.environment_name}-lpa-applications"
+  description   = "capture events from dynamodb stream and pass to event bus"
+  desired_state = "RUNNING"
+  enrichment    = null
+  name_prefix   = null
+  role_arn      = aws_iam_role.lpa_applications_pipe[0].arn
+  source        = aws_dynamodb_table.lpa_uid[0].stream_arn
+  target        = aws_cloudwatch_event_bus.lpa_applications[0].arn
+  source_parameters {
+    dynamodb_stream_parameters {
+      batch_size                         = 1
+      maximum_batching_window_in_seconds = 0
+      maximum_record_age_in_seconds      = -1
+      maximum_retry_attempts             = 0
+      on_partial_batch_item_failure      = null
+      parallelization_factor             = 1
+      starting_position                  = "LATEST"
+    }
+  }
+}
+
+resource "aws_iam_role" "lpa_applications_pipe" {
+  count              = var.is_primary ? 1 : 0
+  name               = "${var.environment_name}-lpa-applications-pipe"
+  assume_role_policy = data.aws_iam_policy_document.lpa_applications_assume_role.json
+  path               = "/service-role/"
+}
+
+data "aws_iam_policy_document" "lpa_applications_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    effect  = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["pipes.amazonaws.com"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:pipes:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:pipe/${var.environment_name}-lpa-applications"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "lpa_applications_pipe_source" {
+  count  = var.is_primary ? 1 : 0
+  name   = "${var.environment_name}-DynamoDbPipeSource"
+  policy = data.aws_iam_policy_document.lpa_applications_dynamodb_source.json
+  role   = aws_iam_role.lpa_applications_pipe[0].id
+}
+
+data "aws_iam_policy_document" "lpa_applications_dynamodb_source" {
+  statement {
+    actions = [
+      "dynamodb:DescribeStream",
+      "dynamodb:GetRecords",
+      "dynamodb:GetShardIterator",
+      "dynamodb:ListStreams",
+    ]
+    effect    = "Allow"
+    resources = aws_dynamodb_table.lpa_uid[*].stream_arn
+  }
+}
+
+resource "aws_iam_role_policy" "lpa_applications_pipe_target" {
+  count  = var.is_primary ? 1 : 0
+  name   = "${var.environment_name}-EventBusPipeTarget"
+  policy = data.aws_iam_policy_document.lpa_applications_eventbus_target.json
+  role   = aws_iam_role.lpa_applications_pipe[0].id
+}
+
+data "aws_iam_policy_document" "lpa_applications_eventbus_target" {
+  statement {
+    actions = [
+      "events:PutEvents"
+    ]
+    effect    = "Allow"
+    resources = aws_cloudwatch_event_bus.lpa_applications[*].arn
+  }
+}
+
+# Temporary SQS queue to enable debugging of events
+resource "aws_cloudwatch_event_rule" "receive_insert" {
+  count          = var.is_primary ? 1 : 0
+  name           = "${var.environment_name}-receive-insert-lpa-applications"
+  description    = "put insert events from event bus onto queue"
+  event_bus_name = aws_cloudwatch_event_bus.lpa_applications[0].name
+
+  event_pattern  = jsonencode({
+    source      = ["lpa-applications"],
+    detail-type = ["insert"]
+  })
+}
+
+resource "aws_sqs_queue" "receive_insert" {
+  count                       = var.is_primary ? 1 : 0
+  name                        = "${var.environment_name}-receive-insert-lpa-applications"
+  fifo_queue                  = false
+  content_based_deduplication = false
+}
+
+resource "aws_cloudwatch_event_target" "receive_insert" {
+  count          = var.is_primary ? 1 : 0
+  target_id      = "${var.environment_name}-receive-insert-lpa-applications"
+  arn            = aws_sqs_queue.receive_insert[0].arn
+  event_bus_name = aws_cloudwatch_event_bus.lpa_applications[0].name
+  rule           = aws_cloudwatch_event_rule.receive_insert[0].name
+}

--- a/terraform/modules/region/variables.tf
+++ b/terraform/modules/region/variables.tf
@@ -31,6 +31,10 @@ variable "app_version" {
   type = string
 }
 
+variable "target_event_bus_arn" {
+  type = string
+}
+
 locals {
   environment_name     = "${var.environment_name}-${data.aws_region.current.name}"
   policy_region_prefix = lower(replace(data.aws_region.current.name, "-", ""))


### PR DESCRIPTION
When a record is changed in the DynamoDB table, it streams to an AWS Pipe. The Pipe filters to only insert events (so updates and deletes are ignored), and transforms the data from the stream into the following structure:
```json
{
  "uid": "M-123456789012",
  "source": "APPLICANT",
  "type": "hw",
  "donor": {
    "name": "Jack Rubik",
    "dob": "1938-03-18",
    "postcode": "W8A0IK"
  }
}
```
It also sets the source and detail-type to match [our definition](https://opgtransform.atlassian.net/wiki/spaces/POAS/pages/3647143937/POAS+Events).