### PR TITLE
Use raw JSON for input template

### DIFF
--- a/terraform/modules/region/lpa_applications.tf
+++ b/terraform/modules/region/lpa_applications.tf
@@ -31,17 +31,19 @@ resource "aws_pipes_pipe" "lpa_applications" {
   }
 
   target_parameters {
-    input_template = jsonencode({
-      uid       = "<$.dynamodb.NewImage.uid.S>",
-      source    = "<$.dynamodb.NewImage.source.S>",
-      type      = "<$.dynamodb.NewImage.type.S>",
-      createdAt = "<$.dynamodb.NewImage.created_at.S>",
-      donor = {
-        name     = "<$.dynamodb.NewImage.donor.M.name.S>",
-        dob      = "<$.dynamodb.NewImage.donor.M.dob.S>",
-        postcode = "<$.dynamodb.NewImage.donor.M.postcode.S>",
-      }
-    })
+    input_template = <<EOT
+    {
+      "createdAt": "<$.dynamodb.NewImage.created_at.S>",
+      "donor": {
+        "dob": "<$.dynamodb.NewImage.donor.M.dob.S>",
+        "name": "<$.dynamodb.NewImage.donor.M.name.S>",
+        "postcode": "<$.dynamodb.NewImage.donor.M.postcode.S>"
+      },
+      "source": "<$.dynamodb.NewImage.source.S>",
+      "type": "<$.dynamodb.NewImage.type.S>",
+      "uid": "<$.dynamodb.NewImage.uid.S>"
+    }
+    EOT
 
     eventbridge_event_bus_parameters {
       source      = "opg.poas.uid"


### PR DESCRIPTION
Using `json_encode` causes Terraform to encode the `<` as `\u003c`, which is what ends up in AWS. AWS fails to do the input transform with this encoding (though, confusingly, it succeeds when testing in the console).

Fixes VEGA-1912 #patch