### PR TITLE
MLPAB-1655 allow MRLPA events received lambda role to call uid service

### DIFF
--- a/terraform/aws/terraform.tfvars.json
+++ b/terraform/aws/terraform.tfvars.json
@@ -5,6 +5,7 @@
             "account_name": "production",
             "allowed_arns": [
                 "arn:aws:iam::313879017102:role/production-app-task-role",
+                "arn:aws:iam::313879017102:role/event-received-production",
                 "arn:aws:iam::313879017102:role/breakglass"
             ]
         },
@@ -13,6 +14,7 @@
             "account_name": "preproduction",
             "allowed_arns": [
                 "arn:aws:iam::792093328875:role/preproduction-app-task-role",
+                "arn:aws:iam::792093328875:role/event-received-preproduction",
                 "arn:aws:iam::792093328875:role/breakglass"
             ]
         },
@@ -26,6 +28,7 @@
                 "arn:aws:iam::653761790766:role/operator",
                 "arn:aws:iam::653761790766:role/breakglass",
                 "arn:aws:iam::313879017102:role/production-app-task-role",
+                "arn:aws:iam::313879017102:role/event-received-production",
                 "arn:aws:iam::653761790766:root"
             ]
         },


### PR DESCRIPTION
Fix missing permission that was preventing the MRLPA service's events handling lambda from calling the UID service.

The MRLPA ECS app task still requires permissions for a dependency healthcheck