### PR TITLE
VEGA-2259 Remove support for digital LPAs with hw or pfa subtypes #major

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ test-api-eu-west-1 test-api-eu-west-2:
 	cd terraform/local && curl \
 		-XPOST $$(terraform output -raw api_stage_uri_$(REGION))cases \
 		-H 'Content-type:application/json' \
-		-d '{"source":"APPLICANT","type":"hw","donor":{"name":"Jack Rubik","dob":"1938-03-18","postcode":"W8A0IK"}}'
+		-d '{"source":"APPLICANT","type":"personal-welfare","donor":{"name":"Jack Rubik","dob":"1938-03-18","postcode":"W8A0IK"}}'
 	@echo ""
 
 	cd terraform/local && curl \

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -32,8 +32,6 @@ paths:
                 type:
                   type: string
                   enum:
-                    - "hw"
-                    - "pfa"
                     - "property-and-affairs"
                     - "personal-welfare"
                 source:

--- a/lambda/create-case/main.go
+++ b/lambda/create-case/main.go
@@ -19,8 +19,6 @@ import (
 type LpaType string
 
 const (
-	LpaTypeHealthAndWelfare   LpaType = "hw"
-	LpaTypePersonalAndFinance LpaType = "pfa"
 	LpaTypePersonalWelfare    LpaType = "personal-welfare"
 	LpaTypePropertyAndAffairs LpaType = "property-and-affairs"
 )

--- a/lambda/create-case/main_test.go
+++ b/lambda/create-case/main_test.go
@@ -133,7 +133,7 @@ func TestHandleEventErrorIfFieldsAreInvalid(t *testing.T) {
 	})
 	assert.Contains(t, problem.Errors, Error{
 		Source: "/type",
-		Detail: "must be hw, pfa, personal-welfare or property-and-affairs",
+		Detail: "must be personal-welfare or property-and-affairs",
 	})
 	assert.Contains(t, problem.Errors, Error{
 		Source: "/donor/dob",

--- a/lambda/create-case/validation.go
+++ b/lambda/create-case/validation.go
@@ -29,10 +29,10 @@ func validate(data Request) (bool, []Error) {
 			Source: "/type",
 			Detail: "required",
 		})
-	} else if data.Type != LpaTypeHealthAndWelfare && data.Type != LpaTypePersonalAndFinance && data.Type != LpaTypePersonalWelfare && data.Type != LpaTypePropertyAndAffairs {
+	} else if data.Type != LpaTypePersonalWelfare && data.Type != LpaTypePropertyAndAffairs {
 		validationErrors = append(validationErrors, Error{
 			Source: "/type",
-			Detail: fmt.Sprintf("must be %s, %s, %s or %s", LpaTypeHealthAndWelfare, LpaTypePersonalAndFinance, LpaTypePersonalWelfare, LpaTypePropertyAndAffairs),
+			Detail: fmt.Sprintf("must be %s or %s", LpaTypePersonalWelfare, LpaTypePropertyAndAffairs),
 		})
 	}
 

--- a/scripts/uid_tester/uid-tester.go
+++ b/scripts/uid_tester/uid-tester.go
@@ -26,7 +26,7 @@ type RequestSigner struct {
 
 func main() {
 	baseUrl := flag.String("baseUrl", "https://development.lpa-uid.api.opg.service.justice.gov.uk", "Base URL of UID service (defaults to 'https://development.lpa-uid.api.opg.service.justice.gov.uk'")
-	requestBody := flag.String("body", `{"type":"pfa","source":"APPLICANT","donor":{"name":"Jamie Smith","dob":"2000-01-02","postcode":"B14 7ED"}}`, "Body POSTed to the service (defaults to a valid body)")
+	requestBody := flag.String("body", `{"type":"property-and-affairs","source":"APPLICANT","donor":{"name":"Jamie Smith","dob":"2000-01-02","postcode":"B14 7ED"}}`, "Body POSTed to the service (defaults to a valid body)")
 
 	flag.Parse()
 

--- a/terraform/modules/region/cloudwatch.tf
+++ b/terraform/modules/region/cloudwatch.tf
@@ -102,7 +102,7 @@ resource "aws_cloudwatch_log_metric_filter" "missing_type_errors" {
 
 resource "aws_cloudwatch_log_metric_filter" "invalid_type_errors" {
   name           = "${local.environment_name}-invalid-type-errors"
-  pattern        = "{$.problem.error_string = \"*/type must be hw or pfa*\"}"
+  pattern        = "{$.problem.error_string = \"*/type must be personal-welfare or property-and-affairs*\"}"
   log_group_name = aws_cloudwatch_log_group.lpa_uid.name
 
   metric_transformation {


### PR DESCRIPTION
These are no longer sent by clients requesting UIDs for digital LPAs, so can be removed from the API.