### PR TITLE
`docker-compose` -> `docker compose`

### DIFF
--- a/.github/workflows/pact-provider-verification.yml
+++ b/.github/workflows/pact-provider-verification.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Verify specified Pact
         if: ${{ github.event_name == 'repository_dispatch' }}
         run: |
-          docker-compose run --rm pact-verifier \
+          docker compose run --rm pact-verifier \
             --provider-version=$(git rev-parse HEAD) \
             --provider-branch=main \
             --publish \
@@ -30,7 +30,7 @@ jobs:
       - name: Verify pacts, including pending
         if: ${{ github.event_name == 'push' }}
         run: |
-          docker-compose run --rm pact-verifier \
+          docker compose run --rm pact-verifier \
             --provider-version=$(git rev-parse HEAD) \
             --provider-branch=main \
             --publish \
@@ -41,7 +41,7 @@ jobs:
       - name: Verify pacts are still upheld
         if: ${{ github.event_name == 'pull_request' }}
         run: |
-          docker-compose run --rm pact-verifier \
+          docker compose run --rm pact-verifier \
             --provider-version=$(git rev-parse HEAD) \
             --provider-branch=${{ github.head_ref }} \
             --consumer-version-selectors='{"mainBranch": true}'

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 SHELL = '/bin/bash'
 
 build:
-	docker-compose build --parallel lambda-create-case
+	docker compose build --parallel lambda-create-case
 
 up:
-	docker-compose up -d localstack
+	docker compose up -d localstack
 
 	cd terraform/local && terraform init
 	cd terraform/local && terraform apply -auto-approve
@@ -29,7 +29,7 @@ test:
 	go test -count 1 ./lambda/create-case/...
 
 down:
-	docker-compose down
+	docker compose down
 	rm -rf terraform/local/terraform.tfstate.d
 	rm -f terraform/local/terraform.state
 	rm -f terraform/local/terraform.state.backup
@@ -44,9 +44,9 @@ run-structurizr-export:
 	export -workspace /usr/local/structurizr/workspace.dsl -format mermaid
 
 get-item:
-	docker-compose exec localstack \
+	docker compose exec localstack \
 		awslocal dynamodb get-item --table-name lpa-uid-local --key '{"uid":{"S":"$(UID)"}}' --region eu-west-1
 
 scan:
-	docker-compose exec localstack \
+	docker compose exec localstack \
 		awslocal dynamodb scan --table-name lpa-uid-local --region eu-west-1


### PR DESCRIPTION
GitHub Actions runners don't support the v1 syntax any more

Fixes CTC-162 #patch